### PR TITLE
fix "A protocol message was rejected because it was too big"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+build
+dist
+*_pb2.py
+*.egg-info


### PR DESCRIPTION
"A protocol message was rejected because it was too big" occurs when the map bin file is too big. 